### PR TITLE
Add the possibility to scrollToItemAtIndexPath

### DIFF
--- a/Pod/Classes/ARNRouletteWheelView.m
+++ b/Pod/Classes/ARNRouletteWheelView.m
@@ -65,4 +65,21 @@
     ((ARNRouletteWheelLayout *)self.collectionViewLayout).itemSize = itemSize;
 }
 
+#pragma mark - Interacting with the collection view
+- (void)scrollToItemAtIndexPath:(NSIndexPath *)indexPath atScrollPosition:(UICollectionViewScrollPosition)scrollPosition animated:(BOOL)animated {
+    if (indexPath.section == 0 && scrollPosition == UICollectionViewScrollPositionCenteredHorizontally) {
+        [self arn_positionToCenterItemAtIndex:indexPath.row animated:animated];
+    }
+}
+
+- (void)arn_positionToCenterItemAtIndex:(NSInteger)index animated:(BOOL)animated {
+    NSInteger totalItems = [self.dataSource collectionView:self numberOfItemsInSection:0];
+    if (index != NSNotFound && index < totalItems) {
+        CGFloat csw = self.contentSize.width;
+        CGFloat inset = self.frame.size.width;
+        CGFloat step = (csw - inset) / (totalItems - 1);
+        [self setContentOffset:CGPointMake(step * index, self.contentOffset.y) animated:animated];
+    }
+}
+
 @end


### PR DESCRIPTION
Add the possibility to scroll to item at index path with position 'centred horizontally'

- override scrollToItemAtIndexPath method
- calculate the content offset for item at index path
- use setContentOffset method to scroll to item at index